### PR TITLE
copy_paste and support to more services

### DIFF
--- a/Code/Settings/ModSettings.cs
+++ b/Code/Settings/ModSettings.cs
@@ -22,6 +22,13 @@ namespace TransferController
         private static readonly SavedInputKey uuiSavedKey = new SavedInputKey("Transfer Controller hotkey", "Transfer Controller hotkey", key: KeyCode.T, control: true, shift: false, alt: true, false);
 
 
+        [XmlIgnore]
+        public static readonly SavedInputKey keyCopy = new SavedInputKey(nameof(keyCopy), SettingsFileName, SavedInputKey.Encode(KeyCode.C, true, false, false), true);
+
+        [XmlIgnore]
+        public static readonly SavedInputKey keyPaste = new SavedInputKey(nameof(keyPaste), SettingsFileName, SavedInputKey.Encode(KeyCode.V, true, false, false), true);
+
+
         /// <summary>
         /// Panel hotkey as ColossalFramework SavedInputKey.
         /// </summary>

--- a/Code/TransferData/TransferDataUtils.cs
+++ b/Code/TransferData/TransferDataUtils.cs
@@ -86,10 +86,11 @@ namespace TransferController
                         return 1;
                     }
                     // Boiler station
-                    else if (buildingInfo.GetAI() is HeatingPlantAI heatingPlantAI && buildingInfo.m_class.m_level == ItemClass.Level.Level2 && heatingPlantAI.m_resourceType != TransferManager.TransferReason.None)
+                    else if (buildingInfo.GetAI() is HeatingPlantAI heatingPlantAI && buildingInfo.m_class.m_level == ItemClass.Level.Level2 && heatingPlantAI.m_resourceType == TransferManager.TransferReason.Oil)
                     {
-                        transfers[0].panelTitle = "boiler station import oil";
-                        transfers[0].outsideText = null;
+                        transfers[0].panelTitle = "Boiler Station import oil";
+                        transfers[0].outsideText = Translations.Translate("TFC_BLD_IMP");
+                        transfers[0].outsideTip = Translations.Translate("TFC_BLD_IMP_TIP");
                         transfers[0].recordNumber = ServiceLimits.IncomingMask;
                         transfers[0].reason = TransferManager.TransferReason.Oil;
                         transfers[0].nextRecord = 0;
@@ -116,7 +117,7 @@ namespace TransferController
                     // shelters import goods
                     else if (buildingInfo.GetAI() is ShelterAI)
                     {
-                        transfers[0].panelTitle = "import food to shelter";
+                        transfers[0].panelTitle = "Import Goods to Shelter";
                         transfers[0].outsideText = Translations.Translate("TFC_BLD_IMP");
                         transfers[0].outsideTip = Translations.Translate("TFC_BLD_IMP_TIP");
                         transfers[0].recordNumber = ServiceLimits.IncomingMask;
@@ -131,9 +132,10 @@ namespace TransferController
                     if(buildingInfo.GetAI() is PowerPlantAI powerPlantAI && powerPlantAI.m_resourceType != TransferManager.TransferReason.None)
                     {
                         transfers[0].panelTitle = "import " + powerPlantAI.m_resourceType.ToString();
-                        transfers[0].outsideText = null;
+                        transfers[0].outsideText = Translations.Translate("TFC_BLD_IMP");
+                        transfers[0].outsideTip = Translations.Translate("TFC_BLD_IMP_TIP");
                         transfers[0].recordNumber = ServiceLimits.IncomingMask;
-                        transfers[0].reason = TransferManager.TransferReason.None;
+                        transfers[0].reason = powerPlantAI.m_resourceType;
                         transfers[0].nextRecord = 0;
                         return 1;
                     }

--- a/Code/TransferData/TransferDataUtils.cs
+++ b/Code/TransferData/TransferDataUtils.cs
@@ -45,7 +45,6 @@ namespace TransferController
                 case ItemClass.Service.FireDepartment:
                 case ItemClass.Service.HealthCare:
                 case ItemClass.Service.PlayerEducation:
-                case ItemClass.Service.Disaster:
                     // Basic service offering; incoming restrictions only, generic title, no specific reason.
                     transfers[0].panelTitle = Translations.Translate("TFC_GEN_SER");
                     transfers[0].outsideText = null;
@@ -53,7 +52,30 @@ namespace TransferController
                     transfers[0].reason = TransferManager.TransferReason.None;
                     transfers[0].nextRecord = 0;
                     return 1;
-
+                case ItemClass.Service.Water:
+                    // Basic service offering; incoming restrictions only, generic title, no specific reason.
+                    if(buildingInfo.m_class.m_level == ItemClass.Level.Level1)
+                    {
+                        transfers[0].panelTitle = Translations.Translate("TFC_GEN_SER");
+                        transfers[0].outsideText = null;
+                        transfers[0].recordNumber = ServiceLimits.IncomingMask;
+                        transfers[0].reason = TransferManager.TransferReason.FloodWater;
+                        transfers[0].nextRecord = 0;
+                        return 1;
+                    }
+                    return 0;
+                case ItemClass.Service.Disaster:
+                    transfers[0].panelTitle = "Disastor response vehicle restrictions";
+                    transfers[0].outsideText = null;
+                    transfers[0].recordNumber = ServiceLimits.IncomingMask;
+                    transfers[0].reason = TransferManager.TransferReason.Collapsed;
+                    transfers[0].nextRecord = 0;
+                    transfers[1].panelTitle = "Disastor response helicopter restrictions";
+                    transfers[1].outsideText = null;
+                    transfers[1].recordNumber = ServiceLimits.IncomingMask + 1;
+                    transfers[1].reason = TransferManager.TransferReason.Collapsed2;
+                    transfers[1].nextRecord = 0;
+                    return 2;
                 case ItemClass.Service.PoliceDepartment:
                     var building = Singleton<BuildingManager>.instance.m_buildings.m_buffer[buildingID];
 

--- a/Code/TransferData/TransferDataUtils.cs
+++ b/Code/TransferData/TransferDataUtils.cs
@@ -42,7 +42,6 @@ namespace TransferController
             switch (buildingInfo.GetService())
             {
                 case ItemClass.Service.Education:
-                case ItemClass.Service.FireDepartment:
                 case ItemClass.Service.HealthCare:
                 case ItemClass.Service.PlayerEducation:
                     // Basic service offering; incoming restrictions only, generic title, no specific reason.
@@ -52,9 +51,28 @@ namespace TransferController
                     transfers[0].reason = TransferManager.TransferReason.None;
                     transfers[0].nextRecord = 0;
                     return 1;
+                case ItemClass.Service.FireDepartment:
+                    // Basic service offering; incoming restrictions only, generic title, no specific reason.
+                    transfers[0].panelTitle = Translations.Translate("TFC_GEN_SER");
+                    transfers[0].outsideText = null;
+                    transfers[0].recordNumber = ServiceLimits.IncomingMask;
+                    transfers[0].reason = TransferManager.TransferReason.Fire;
+                    transfers[0].nextRecord = 0;
+
+                    if (buildingInfo.GetAI() is HelicopterDepotAI)
+                    {
+                        transfers[1].panelTitle = "Forest fire restrictions";
+                        transfers[1].outsideText = null;
+                        transfers[1].recordNumber = ServiceLimits.IncomingMask +1;
+                        transfers[1].reason = TransferManager.TransferReason.Fire2;
+                        transfers[1].nextRecord = 0;
+                        return 2;
+                    }
+
+                    return 1;
                 case ItemClass.Service.Water:
                     // Basic service offering; incoming restrictions only, generic title, no specific reason.
-                    if(buildingInfo.m_class.m_level == ItemClass.Level.Level1)
+                    if(buildingInfo.GetAI() is WaterFacilityAI)
                     {
                         transfers[0].panelTitle = Translations.Translate("TFC_GEN_SER");
                         transfers[0].outsideText = null;
@@ -303,6 +321,43 @@ namespace TransferController
 
                     // Undefined service.
                     Logging.Message("undefined garbage service");
+                    return 0;
+
+                case ItemClass.Service.Fishing:
+                    if(buildingInfo.GetAI() is FishFarmAI || buildingInfo.GetAI() is FishingHarborAI)
+                    {
+                        transfers[0].panelTitle = "Deliver fish";
+                        transfers[0].outsideText = null;
+                        transfers[0].recordNumber = ServiceLimits.OutgoingMask;
+                        transfers[0].reason = TransferManager.TransferReason.Fish;
+                        transfers[0].nextRecord = 0;
+                        return 1;
+                    }
+                    else if(buildingInfo.GetAI() is MarketAI)
+                    {
+                        transfers[0].panelTitle = "Fish delivery from harbor";
+                        transfers[0].outsideText = null;
+                        transfers[0].recordNumber = ServiceLimits.IncomingMask;
+                        transfers[0].reason = TransferManager.TransferReason.Fish;
+                        transfers[0].nextRecord = 0;
+                        return 1;
+                    }
+                    else if(buildingInfo.GetAI() is ProcessingFacilityAI)
+                    {
+                        transfers[0].panelTitle = "Fish Delivery from harbor";
+                        transfers[0].outsideText = null;
+                        transfers[0].recordNumber = ServiceLimits.IncomingMask;
+                        transfers[0].reason = TransferManager.TransferReason.Fish;
+                        transfers[0].nextRecord = 0;
+                        transfers[1].panelTitle = "Canned fish for sale";
+                        transfers[1].outsideText = null;
+                        transfers[1].recordNumber = ServiceLimits.OutgoingMask;
+                        transfers[1].reason = TransferManager.TransferReason.Goods;
+                        transfers[1].nextRecord = 0;
+                        return 2;
+                    }
+                    // Undefined service.
+                    Logging.Message("undefined fish service");
                     return 0;
 
                 default:

--- a/Code/TransferData/TransferDataUtils.cs
+++ b/Code/TransferData/TransferDataUtils.cs
@@ -251,7 +251,7 @@ namespace TransferController
                         transfers[0].nextRecord = 0;
                         return 1;
                     }
-                    else if (buildingInfo.m_buildingAI is ProcessingFacilityAI)
+                    else if (buildingInfo.m_buildingAI is ProcessingFacilityAI && buildingInfo.m_class.m_level < ItemClass.Level.Level5)
                     {
                         transfers[0].panelTitle = Translations.Translate("TFC_GEN_BUY");
                         transfers[0].outsideText = Translations.Translate("TFC_BLD_IMP");
@@ -284,8 +284,8 @@ namespace TransferController
                     else if (buildingInfo.m_buildingAI is WarehouseAI)
                     {
                         transfers[0].panelTitle = Translations.Translate("TFC_GEN_BUY");
-                        transfers[0].outsideText = Translations.Translate("TFC_BLD_EXP");
-                        transfers[0].outsideTip = Translations.Translate("TFC_BLD_EXP_TIP");
+                        transfers[0].outsideText = Translations.Translate("TFC_BLD_IMP");
+                        transfers[0].outsideTip = Translations.Translate("TFC_BLD_IMP_TIP");
                         transfers[0].recordNumber = ServiceLimits.IncomingMask;
                         transfers[0].reason = TransferManager.TransferReason.None;
                         transfers[0].nextRecord = 0;

--- a/Code/TransferData/TransferDataUtils.cs
+++ b/Code/TransferData/TransferDataUtils.cs
@@ -307,15 +307,13 @@ namespace TransferController
                         transfers[1].nextRecord = 0;
 
                         transfers[2].panelTitle = Translations.Translate("TFC_MAI_OGM");
-                        transfers[2].outsideText = Translations.Translate("TFC_BLD_EXP");
-                        transfers[2].outsideTip = Translations.Translate("TFC_BLD_EXP_TIP");
+                        transfers[2].outsideText = null;
                         transfers[2].recordNumber = ServiceLimits.OutgoingMask + 1;
                         transfers[2].reason = TransferManager.TransferReason.OutgoingMail;
                         transfers[2].nextRecord = 0;
 
                         transfers[3].panelTitle = Translations.Translate("TFC_MAI_ICM");
-                        transfers[3].outsideText = Translations.Translate("TFC_BLD_IMP");
-                        transfers[3].outsideTip = Translations.Translate("TFC_BLD_IMP_TIP");
+                        transfers[3].outsideText = null;
                         transfers[3].recordNumber = ServiceLimits.IncomingMask + 1;
                         transfers[3].reason = TransferManager.TransferReason.IncomingMail;
                         transfers[3].nextRecord = 0;

--- a/Code/TransferData/TransferDataUtils.cs
+++ b/Code/TransferData/TransferDataUtils.cs
@@ -55,33 +55,102 @@ namespace TransferController
                     return 1;
 
                 case ItemClass.Service.PoliceDepartment:
-                    // TODO: Prison Helicopter Mod transfers go here.
-                    /*if ((Singleton<BuildingManager>.instance.m_buildings.m_buffer[currentBuilding].m_flags & Building.Flags.Downgrading) != 0)
-                    {
-                        transfers[2].panelTitle = "?Collect from police stations?";
-                        transfers[2].outsideText = null;
-                        transfers[2].recordNumber = ServiceLimits.IncomingMask + 1;
-                        transfers[2].reason = (TransferManager.TransferReason)125;
-                        transfers[0].nextRecord = ServiceLimits.IncomingMask + 1;
-                        transfers[2].nextRecord = 0;
-                    }
+                    var building = Singleton<BuildingManager>.instance.m_buildings.m_buffer[buildingID];
 
-                    else*/
+                    // Police helicopter depot
+                    if(buildingInfo.GetAI() is HelicopterDepotAI)
                     {
-                        // Normal police stations.
                         transfers[0].panelTitle = Translations.Translate("TFC_GEN_SER");
                         transfers[0].outsideText = null;
                         transfers[0].recordNumber = ServiceLimits.IncomingMask;
                         transfers[0].reason = TransferManager.TransferReason.Crime;
                         transfers[0].nextRecord = 0;
-                        transfers[1].panelTitle = Translations.Translate("TFC_POL_CMO");
-                        transfers[1].outsideText = null;
-                        transfers[1].recordNumber = ServiceLimits.OutgoingMask;
-                        transfers[1].reason = TransferManager.TransferReason.CriminalMove;
-                        transfers[1].nextRecord = 0;
-                    }
-                    return 2;
 
+                        // Prison Helicopter Mod
+                        if ((building.m_flags & Building.Flags.Downgrading) == 0)
+                        {
+                            transfers[1].panelTitle = "Prison Helicopters restrictions";
+                            transfers[1].outsideText = null;
+                            transfers[1].recordNumber = ServiceLimits.IncomingMask + 1;
+                            transfers[1].reason = (TransferManager.TransferReason)126;
+                            transfers[1].nextRecord = 0;
+
+                             return 2;
+                        }
+
+                        return 1;
+                    }
+                    else 
+                    {
+                        // Prison
+                        if(buildingInfo.m_class.m_level >= ItemClass.Level.Level4)
+                        {
+                            transfers[0].panelTitle = Translations.Translate("TFC_GEN_SER");
+                            transfers[0].outsideText = null;
+                            transfers[0].recordNumber = ServiceLimits.IncomingMask;
+                            transfers[0].reason = TransferManager.TransferReason.CriminalMove;
+                            transfers[0].nextRecord = 0;
+
+                            // Prison Helicopter Mod
+                            if (buildingInfo.m_buildingAI.GetType().Name.Equals("PrisonCopterPoliceStationAI"))
+                            {
+                                transfers[1].panelTitle = "Prisoners transfer via helicopters";
+                                transfers[1].outsideText = null;
+                                transfers[1].recordNumber = ServiceLimits.OutgoingMask;
+                                transfers[1].reason = (TransferManager.TransferReason)126;
+                                transfers[1].nextRecord = 0;
+                                return 2;
+                            }
+
+                            return 1;
+                        }
+                        else
+                        {
+                            // Normal police station
+                            transfers[0].panelTitle = Translations.Translate("TFC_GEN_SER");
+                            transfers[0].outsideText = null;
+                            transfers[0].recordNumber = ServiceLimits.IncomingMask;
+                            transfers[0].reason = TransferManager.TransferReason.Crime;
+                            transfers[0].nextRecord = 0;
+                            transfers[1].panelTitle = Translations.Translate("TFC_POL_CMO");
+                            transfers[1].outsideText = null;
+                            transfers[1].recordNumber = ServiceLimits.OutgoingMask;
+                            transfers[1].reason = TransferManager.TransferReason.CriminalMove;
+                            transfers[1].nextRecord = 0;
+
+                            // Prison Helicopter Mod
+                            if (buildingInfo.m_buildingAI.GetType().Name.Equals("PrisonCopterPoliceStationAI"))
+                            {
+                                // Small police station
+                                if ((building.m_flags & Building.Flags.Downgrading) != 0)
+                                {
+                                    transfers[2].panelTitle = "Criminal transfer to a central police station";
+                                    transfers[2].outsideText = null;
+                                    transfers[2].recordNumber = ServiceLimits.OutgoingMask + 1;
+                                    transfers[2].reason = (TransferManager.TransferReason)125;
+                                    transfers[2].nextRecord = 0;
+                                    return 3;
+                                }
+                                // Big police station
+                                else
+                                {
+                                    transfers[2].panelTitle = "Criminal air transfer to prison";
+                                    transfers[2].outsideText = null;
+                                    transfers[2].recordNumber = ServiceLimits.OutgoingMask + 1;
+                                    transfers[2].reason = (TransferManager.TransferReason)126;
+                                    transfers[2].nextRecord = 0;
+                                    transfers[3].panelTitle = "Criminal transfer from a local police stations";
+                                    transfers[3].outsideText = null;
+                                    transfers[3].recordNumber = ServiceLimits.IncomingMask + 1;
+                                    transfers[3].reason = (TransferManager.TransferReason)125;
+                                    transfers[3].nextRecord = 0;
+                                    return 4;
+                                }
+                            }
+
+                            return 2;
+                        }
+                    }
                 case ItemClass.Service.Industrial:
                 case ItemClass.Service.PlayerIndustry:
                     // Industrial buildings get both incoming and outgoing restrictions (buy/sell).

--- a/Code/TransferData/TransferDataUtils.cs
+++ b/Code/TransferData/TransferDataUtils.cs
@@ -270,21 +270,7 @@ namespace TransferController
                         transfers[1].reason = TransferManager.TransferReason.SortedMail;
                         transfers[1].nextRecord = 0;
 
-                        transfers[2].panelTitle = "Export Mail";
-                        transfers[2].outsideText = Translations.Translate("TFC_BLD_IMP");
-                        transfers[2].outsideTip = Translations.Translate("TFC_BLD_IMP_TIP");
-                        transfers[2].recordNumber = ServiceLimits.IncomingMask;
-                        transfers[2].reason = TransferManager.TransferReason.IncomingMail;
-                        transfers[2].nextRecord = 0;
-
-                        transfers[3].panelTitle = "Import Mail";
-                        transfers[3].outsideText = Translations.Translate("TFC_BLD_EXP");
-                        transfers[3].outsideTip = Translations.Translate("TFC_BLD_EXP_TIP");
-                        transfers[3].recordNumber = ServiceLimits.OutgoingMask;
-                        transfers[3].reason = TransferManager.TransferReason.OutgoingMail;
-                        transfers[3].nextRecord = 0;
-
-                        return 4;
+                        return 2;
                     }
                     Logging.Message("undefined public transport service");
                     return 0;

--- a/Code/TransferData/TransferDataUtils.cs
+++ b/Code/TransferData/TransferDataUtils.cs
@@ -206,7 +206,8 @@ namespace TransferController
                     if (buildingInfo.m_buildingAI is IndustrialExtractorAI)
                     {
                         transfers[0].panelTitle = Translations.Translate("TFC_GEN_SEL");
-                        transfers[0].outsideText = null;
+                        transfers[0].outsideText = Translations.Translate("TFC_BLD_EXP");
+                        transfers[0].outsideTip = Translations.Translate("TFC_BLD_EXP_TIP");
                         transfers[0].recordNumber = ServiceLimits.OutgoingMask;
                         transfers[0].reason = TransferManager.TransferReason.None;
                         transfers[0].nextRecord = 0;

--- a/Code/TransferData/TransferDataUtils.cs
+++ b/Code/TransferData/TransferDataUtils.cs
@@ -63,7 +63,7 @@ namespace TransferController
                     {
                         transfers[1].panelTitle = "Forest fire restrictions";
                         transfers[1].outsideText = null;
-                        transfers[1].recordNumber = ServiceLimits.IncomingMask +1;
+                        transfers[1].recordNumber = ServiceLimits.IncomingMask + 1;
                         transfers[1].reason = TransferManager.TransferReason.Fire2;
                         transfers[1].nextRecord = 0;
                         return 2;
@@ -211,7 +211,7 @@ namespace TransferController
                 case ItemClass.Service.Road:
                 case ItemClass.Service.Beautification:
                     // Maintenance depots only, and only incoming.
-                    if (buildingInfo.GetAI() is MaintenanceDepotAI)
+                    if (buildingInfo.GetAI() is MaintenanceDepotAI || buildingInfo.GetAI() is SnowDumpAI)
                     {
                         transfers[0].panelTitle = Translations.Translate("TFC_GEN_SER");
                         transfers[0].outsideText = null;

--- a/Code/TransferData/TransferDataUtils.cs
+++ b/Code/TransferData/TransferDataUtils.cs
@@ -270,7 +270,21 @@ namespace TransferController
                         transfers[1].reason = TransferManager.TransferReason.SortedMail;
                         transfers[1].nextRecord = 0;
 
-                        return 2;
+                        transfers[2].panelTitle = "Export Mail";
+                        transfers[2].outsideText = Translations.Translate("TFC_BLD_IMP");
+                        transfers[2].outsideTip = Translations.Translate("TFC_BLD_IMP_TIP");
+                        transfers[2].recordNumber = ServiceLimits.IncomingMask;
+                        transfers[2].reason = TransferManager.TransferReason.IncomingMail;
+                        transfers[2].nextRecord = 0;
+
+                        transfers[3].panelTitle = "Import Mail";
+                        transfers[3].outsideText = Translations.Translate("TFC_BLD_EXP");
+                        transfers[3].outsideTip = Translations.Translate("TFC_BLD_EXP_TIP");
+                        transfers[3].recordNumber = ServiceLimits.OutgoingMask;
+                        transfers[3].reason = TransferManager.TransferReason.OutgoingMail;
+                        transfers[3].nextRecord = 0;
+
+                        return 4;
                     }
                     Logging.Message("undefined public transport service");
                     return 0;

--- a/Code/UI/CopyPaste.cs
+++ b/Code/UI/CopyPaste.cs
@@ -1,0 +1,89 @@
+﻿using ColossalFramework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace TransferController
+{
+    public static class CopyPaste
+    {
+
+        internal static ushort BuildingTemplate = 0;
+
+        internal static TransferStruct[] Transfers = new TransferStruct[4];
+
+        /// <summary>
+        /// Check if can copy between buildings
+        /// </summary>
+        /// <param name="source_building">building to copy from (source building)</param>
+        /// <param name="destination_building">building to copy to (destination building)</param>
+        internal static bool CanCopy(ushort source_building, ushort destination_building)
+        {
+            List<byte> source_building_list = new List<byte>();
+            List<byte> destination_building_list = new List<byte>();
+
+            var source_building_transfers = new TransferStruct[4];
+            var destination_building_transfers = new TransferStruct[4];
+
+            var source_building_number = TransferDataUtils.BuildingEligibility(source_building, Singleton<BuildingManager>.instance.m_buildings.m_buffer[source_building].Info, source_building_transfers);
+            var destination_building_number = TransferDataUtils.BuildingEligibility(destination_building, Singleton<BuildingManager>.instance.m_buildings.m_buffer[destination_building].Info, destination_building_transfers);
+            if(source_building_number != destination_building_number)
+            {
+                return false;
+            }
+            foreach (var record in source_building_transfers) 
+            {
+                source_building_list.Add(record.recordNumber);
+            }
+            foreach (var record in destination_building_transfers)
+            {
+                destination_building_list.Add(record.recordNumber);
+            }
+            bool equals = source_building_list.OrderBy(a => a).SequenceEqual(destination_building_list.OrderBy(a => a));
+            if (!equals)
+            {
+                return false;
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Copy policy between buildings.
+        /// </summary>
+        /// <param name="building">Building to copy to (destination building)</param>
+        /// <param name="transfers">Building transfers (destination building)</param>
+        internal static bool CopyPolicyTo(ushort building, TransferStruct[] transfers)
+        {
+            try
+            {
+                ServiceLimits.DeleteEntry(building);
+
+                for (int i = 0; i < transfers.Length; ++i)
+                {
+                    ServiceLimits.SetEnabled(building, transfers[i].recordNumber, ServiceLimits.GetEnabled(BuildingTemplate, Transfers[i].recordNumber), transfers[i].reason, transfers[i].nextRecord);
+
+                    ServiceLimits.SetSameDistrict(building, transfers[i].recordNumber, ServiceLimits.GetSameDistrict(BuildingTemplate, Transfers[i].recordNumber), transfers[i].reason, transfers[i].nextRecord);
+ 
+                    ServiceLimits.SetOutsideConnection(building, transfers[i].recordNumber, ServiceLimits.GetOutsideConnection(BuildingTemplate, Transfers[i].recordNumber), transfers[i].reason, transfers[i].nextRecord);
+
+                    var DistrictsServed = ServiceLimits.GetBuildingDistricts(BuildingTemplate, transfers[i].recordNumber);
+                    if (DistrictsServed != null)
+                    {
+                        foreach (var districtPark in DistrictsServed)
+                        {
+                            ServiceLimits.AddBuildingDistrict(building, transfers[i].recordNumber, districtPark, transfers[i].reason, transfers[i].nextRecord);
+                        }
+                    }
+                }
+ 
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Logging.Error(ex);
+                return false;
+            }
+            
+        }
+    }
+}

--- a/Code/UI/TCTool.cs
+++ b/Code/UI/TCTool.cs
@@ -23,7 +23,6 @@ namespace TransferController
 		/// </summary>
 		public static TCTool Instance => ToolsModifierControl.toolController?.gameObject?.GetComponent<TCTool>();
 
-
 		/// <summary>
 		/// Returns true if the zoning tool is currently active, false otherwise.
 		/// </summary>
@@ -228,6 +227,67 @@ namespace TransferController
 					BuildingPanelManager.SetTarget(building);
 				}
 			}
+
+			if (ModSettings.keyCopy.IsPressed(e))
+            {
+				var transfers = new TransferStruct[4]; 
+                if (building == 0 || 
+                    BuildingManager.instance.m_buildings.m_buffer[building].Info.GetAI() is DummyBuildingAI ||
+                    !TransferDataUtils.BuildingEligibility(building, transfers))
+                {
+                    ModUtils.DisplayMessage(
+                        str1: "Transfer Controller",
+                        str2: $"Cannot copy policy from this building!",
+                        str3: "IconMessage");
+                    return;
+                }
+
+                CopyPaste.BuildingTemplate = building;
+				CopyPaste.Transfers = transfers;
+            }
+
+			if (ModSettings.keyPaste.IsPressed(e))
+            {
+				var transfers = new TransferStruct[4]; 
+                if (CopyPaste.BuildingTemplate == 0)
+                {
+                    ModUtils.DisplayMessage(
+                        str1: "Transfer Controller",
+                        str2: $"Please hover over a valid building and press Ctrl-C to copy its policy first!",
+                        str3: "IconMessage");
+                    return;
+                }
+
+                if (building == 0 ||
+                    BuildingManager.instance.m_buildings.m_buffer[building].Info.GetAI() is DummyBuildingAI ||
+                    !TransferDataUtils.BuildingEligibility(building, transfers))
+                {
+                    ModUtils.DisplayMessage(
+                        str1: "Transfer Controller",
+                        str2: $"Cannot copy policy to this unsupported building!",
+                        str3: "IconMessage");
+                    return;
+                }
+
+                if (!CopyPaste.CanCopy(CopyPaste.BuildingTemplate, building))
+                {
+                    ModUtils.DisplayMessage(
+                        str1: "Transfer Controller",
+                        str2: $"Can only copy-paste policy between buildings of the same policy type!",
+                        str3: "IconMessage");
+                    return;
+                }
+
+                if (!CopyPaste.CopyPolicyTo(building, transfers))
+                {
+                    ModUtils.DisplayMessage(
+                        str1: "Transfer Controller",
+                        str2: $"Could not copy certain supply chain restrictions. Please check results of copy operation!",
+                        str3: "IconMessage");
+                    return;
+                }
+
+            }
 		}
 	}
 }

--- a/Code/UI/TransferPanel.cs
+++ b/Code/UI/TransferPanel.cs
@@ -168,7 +168,7 @@ namespace TransferController
         private bool OutsideConnection
         {
             get => ServiceLimits.GetOutsideConnection(currentBuilding, recordNumber);
-            set => ServiceLimits.SetOutsideConnection(currentBuilding, recordNumber, !value, TransferReason, NextRecord);
+            set => ServiceLimits.SetOutsideConnection(currentBuilding, recordNumber, value, TransferReason, NextRecord);
         }
 
 

--- a/Code/UI/TransferPanel.cs
+++ b/Code/UI/TransferPanel.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using UnityEngine;
 using ColossalFramework.UI;
-
+using ColossalFramework;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace TransferController
 {
@@ -37,7 +39,6 @@ namespace TransferController
         // Current selections.
         private ushort currentBuilding;
         private byte recordNumber;
-
 
         // Event status.
         private bool disableEvents = false;

--- a/Code/Utils/ModUtils.cs
+++ b/Code/Utils/ModUtils.cs
@@ -4,7 +4,10 @@ using System.Reflection;
 using System.Collections.Generic;
 using ICities;
 using ColossalFramework.Plugins;
-
+using ColossalFramework.UI;
+using UnityEngine;
+using ColossalFramework.DataBinding;
+using System;
 
 namespace TransferController
 {
@@ -99,6 +102,31 @@ namespace TransferController
             // If we got here, then we didn't find the assembly.
             Logging.Error("assembly path not found");
             throw new FileNotFoundException(TransferControllerMod.ModName + ": assembly path not found!");
+        }
+
+        /// <summary>
+        /// Display message to the user.
+        /// </summary>
+        internal static void DisplayMessage(string str1, string str2, string str3)
+        {
+            try
+            {
+                var uiComponent = UIView.library.ShowModal("ExceptionPanel");
+                if (uiComponent != null)
+                {
+                    Cursor.lockState = CursorLockMode.None;
+                    Cursor.visible = true;
+                    var component = uiComponent.GetComponent<BindPropertyByKey>();
+                    if (component != null)
+                    {
+                        component.SetProperties(TooltipHelper.Format("title", str1, "message", str2, "img", str3));
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Logging.Error(ex);
+            }
         }
     }
 }

--- a/TransferController.csproj
+++ b/TransferController.csproj
@@ -75,6 +75,7 @@
     <Compile Include="Code\TransferData\TransferDataUtils.cs" />
     <Compile Include="Code\TranslationFramework\TranslationFramework.cs" />
     <Compile Include="Code\TranslationFramework\TranslationXML.cs" />
+    <Compile Include="Code\UI\CopyPaste.cs" />
     <Compile Include="Code\UI\DistrictSelectionPanel\BuildingDistrictSelectionPanel.cs" />
     <Compile Include="Code\UI\TCTool.cs" />
     <Compile Include="Code\UI\TransferPanel.cs" />

--- a/Translations/en.csv
+++ b/Translations/en.csv
@@ -14,12 +14,23 @@ TFC_BLD_IMP_TIP,Permit this building to import from outside connections.
 TFC_BLD_EXP,Allow exports
 TFC_BLD_EXP_TIP,Permit this building to export to outside connections.
 TFC_BLD_NOD,No local district
+TFC_FIR_BUI,Building fire fighting
+TFC_FIR_FOR,Forest fire fighting
+TFC_DIS_TRU,Disaster response trucks
+TFC_DIS_HEL,Disaster response helicopters
+TFC_POL_CMO,Criminal transfer to prison
+TFC_POL_PHO,Prisoner transfer by helicopter
+TFC_POL_PHI,Prisoner collection by helicopter
+TFC_POL_PTO,Prisoner transfer to central station
+TFC_POL_PTI,Prisoner transfer from local station
 TFC_MAI_IML,Local mail collection
 TFC_MAI_OSD,Local mail delivery
 TFC_MAI_OUN,Outgoing unsorted mail
 TFC_MAI_IST,Incoming sorted mail
 TFC_MAI_IUN,Unsorted mail from post offices
 TFC_MAI_OST,Sorted mail to post offices
+TFC_MAI_OGM,Outgoing mail
+TFC_MAI_ICM,Incoming mail
 TFC_GAR_ICO,Garbage collection
 TFC_GAR_ITF,Garbage transfer from collection
 TFC_GAR_OTF,Garbage transfer to processing


### PR DESCRIPTION
Added copy paste to buildings of the same policy.
Added support for my PH mod.
Added support for pumping station and disaster vehicles and helis seperated.
add support for fishing - include the market and the factory. (still need to add export option to factory, fish farm and fish harbor).
add support to forest fires - differ from building fires.