### PR TITLE
fixup compile on mac

### DIFF
--- a/TransferController.csproj
+++ b/TransferController.csproj
@@ -8,7 +8,21 @@
 		<Copyright>Copyright © 2021-22 algernon</Copyright>
 		<Product>$(Title)</Product>
 		<Version>0.7.6</Version>
-		<ManagedDLLPath>$(MSBuildProgramFiles32)/Steam/steamapps/common/Cities_Skylines/Cities_Data/Managed</ManagedDLLPath>
+
+		<!-- Cross-platform managed DLL path guessing functionality -->
+		<SteamPath>$(MSBuildProgramFiles32)/Steam</SteamPath>
+		<SteamPath Condition="! Exists ('$(SteamPath)')">$(HOME)/Library/Application Support/Steam</SteamPath>
+		<SteamPath Condition="! Exists ('$(SteamPath)')">$(ProgramFiles)/Steam</SteamPath>
+		<SteamPath Condition="! Exists ('$(SteamPath)')">$(Registry:HKEY_CURRENT_USER\Software\Valve\Steam@SteamPath)</SteamPath>
+
+		<CSPath>$(SteamPath)/steamapps/common/Cities_Skylines</CSPath>
+
+		<DataGuess>$(CSPath)/Cities.app/Contents/Resources/Data</DataGuess>
+		<DataGuess Condition="! Exists ('$(DataGuess)')">$(CSPath)/Cities_Data</DataGuess>
+
+		<!-- If CITIES_DATA envar is unset, will use DataGuess -->
+		<CITIES_DATA Condition="'$(CITIES_DATA)' == ''">$(DataGuess)</CITIES_DATA>
+		<ManagedDLLPath>$(CITIES_DATA)/Managed</ManagedDLLPath>
 		<AssemblySearchPaths>
 			$(AssemblySearchPaths);
 			$(ManagedDLLPath)
@@ -33,8 +47,11 @@
 	</ItemGroup>
 	<Target Name="DeployToModDirectory" AfterTargets="Build">
 		<PropertyGroup>
-			<DeployDir>$(LOCALAPPDATA)/Colossal Order/Cities_Skylines/Addons/Mods/$(SolutionName)/</DeployDir>
+			<CSAppDataDir>$(LOCALAPPDATA)/Colossal Order/Cities_Skylines</CSAppDataDir>
+			<CSAppDataDir Condition="! Exists ('$(CSAppDataDir)')">$(HOME)/Library/Application Support/Colossal Order/Cities_Skylines</CSAppDataDir>
+			<DeployDir>$(CSAppDataDir)/Addons/Mods/$(SolutionName)/</DeployDir>
 		</PropertyGroup>
+		<Message Importance="High" Text="Deploying Mod to $(DeployDir)"/>
 		<Copy SourceFiles="$(TargetPath)" DestinationFolder="$(DeployDir)" />
 		<Copy SourceFiles="$(TargetDir)/CitiesHarmony.API.dll" DestinationFolder="$(DeployDir)" />
 		<Copy SourceFiles="$(TargetDir)/UnifiedUILib.dll" DestinationFolder="$(DeployDir)" />


### PR DESCRIPTION
also makes deploy cross plat

I was having problems with compiling this project on my Mac. I added some conditional variables to fixup the steam search paths for Mac systems. 

I have not re-tested these changes on PC.

also accepts `CITIES_DATA` envar to have path be directly given rather than guessed