### PR TITLE
add park consideration

### DIFF
--- a/Code/Matching/Matching.cs
+++ b/Code/Matching/Matching.cs
@@ -379,6 +379,19 @@ namespace TransferController
                             continue;
                         }
 
+                        // If within park area with deliveries, skip offers not
+                        // also within the same park area.
+                        // Do not let name `isLocalPark` fool you, this is not a
+                        // boolean - it is a park ID. It is set in
+                        // AddIncomingOffer or AddOutgoingOffer for buildings within
+                        // pedestrian zones that handle deliveries connected to
+                        // a pedestrian road, or in zones with the force deliveries
+                        // policy.
+                        if (offer.m_isLocalPark != candidate.m_isLocalPark)
+                        {
+                            continue;
+                        }
+
                         // Defaults.
                         Vector3 candidatePosition = candidate.Position;
                         ushort candidateBuilding = candidate.Building;
@@ -486,6 +499,14 @@ namespace TransferController
 
                             // Candidate building modifier.
                             distanceModifier *= CheckPreferSameDistrict(candidateBuilding, !incoming, reason);
+                        }
+
+                        // This is a park delivery. Distance is not a consideration
+                        // for intra-park deliveries since they happen
+                        // instantaneously without using a vehicle.
+                        if (offer.m_isLocalPark == candidate.m_isLocalPark)
+                        {
+                            distanceModifier = 0;
                         }
 
                         // Calculate distance between positions - use original offer positions, not owning building positions.


### PR DESCRIPTION
I was having some problems with my buildings within parks experiencing path fails. They would constantly not have enough goods to sell and keep matching against imports which cant reach them due to pedestrian roads.

I noticed some logic present in the decompiled code for the original Transfer Manager missing from this re-implementation. This logic skips potential matches depending on value of `m_isLocalPark`.

`m_isLocalPark` seems to be populated in `AddIncomingOffer`/`AddOutgoingOffer` for trades which should use a park service point for a delivery. I also added some logic to make their distance offers 0, since the goods are always just teleported to their destination.

After making this change I do not see any path fails in transfer logs for my building within pedestrian area. 